### PR TITLE
Require a ledger ID when constructing a Client of a custom network.

### DIFF
--- a/reference/core/Client.md
+++ b/reference/core/Client.md
@@ -57,7 +57,7 @@ client.setOperator(operatorAccountId, operatorPrivateKey);
 
 ### Static Methods
 
-##### `forNetwork` ( `network`: `Map` < `String` , [`AccountId`](../cryptocurrency/AccountId.md) > ): `Client`
+##### `forCustomNetwork` ( `network`: `Map` < `String` , [`AccountId`](../cryptocurrency/AccountId.md) >, `ledgerId`: [`LedgerId`](../LedgerId.md) ): `Client`
 
 Construct a client for a specific network.
 


### PR DESCRIPTION
Currently, it is easy to create a `Client` in an invalid configuration, missing the `LedgerId`

I propose that we deprecate `Client.forNetwork` and replace with `Client.forCustomNetwork` that has the added required parameter, `ledgerId`.